### PR TITLE
Catchup with the changes in tile metadata format

### DIFF
--- a/docker/mvt-elastic/pygeoapi/docker.config.yml
+++ b/docker/mvt-elastic/pygeoapi/docker.config.yml
@@ -117,7 +117,6 @@ resources:
               data: http://elastic_search:9200/ne_110m_populated_places_simple/_mvt/geometry/{z}/{x}/{y}?grid_precision=0
               # index must have a geo_point
               options:
-                metadata_format: default # default | tilejson
                 zoom:
                     min: 0
                     max: 16

--- a/docker/mvt-tippecanoe/pygeoapi/docker.config.yml
+++ b/docker/mvt-tippecanoe/pygeoapi/docker.config.yml
@@ -111,7 +111,6 @@ resources:
               data: tests/data/tiles/ne_110m_lakes/  # local directory tree
               # data: http://localhost:9000/ne_110m_lakes/{z}/{x}/{y}.pbf # tiles stored on a MinIO bucket
               options:
-                metadata_format: default # default | tilejson
                 zoom:
                     min: 0
                     max: 16


### PR DESCRIPTION
With [this](https://github.com/geopython/pygeoapi/pull/1482) PR, the tiles metadata format is no longer an option, as pygeoapi makes the best effort to support all formats.

Note: this should also removed from the demo-pygeoapi config: services/pygeoapi_master/local.config.yml