### PR TITLE
Updates on MVT-elastic docker example

### DIFF
--- a/docker/elastic/docker-compose.yml
+++ b/docker/elastic/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     depends_on:
       - elastic_search
 
+    restart: on-failure
+
   elastic_search:
     build: ./ES
     deploy:

--- a/docker/mvt-elastic/docker-compose.yml
+++ b/docker/mvt-elastic/docker-compose.yml
@@ -53,6 +53,8 @@ services:
 
     depends_on:
       - elastic_search
+      
+    restart: on-failure
 
   elastic_search:
     build: ./ES
@@ -60,11 +62,13 @@ services:
     container_name: elastic
 # Elastic ports may be opened for debugging but should remain closed in
 # production workloads.
-    # ports:
-    #   - 9300:9300
-    #   - 9200:9200
+    ports:
+      - 9300:9300
+      - 9200:9200
     volumes:
       - elastic_search_data:/usr/share/elasticsearch/data
+      # - ./data:/data # Exercise 1 - First - Ready to pull data from here
+
 
 volumes:
   elastic_search_data: {}

--- a/docker/mvt-elastic/docker-compose.yml
+++ b/docker/mvt-elastic/docker-compose.yml
@@ -62,19 +62,18 @@ services:
     container_name: elastic
 # Elastic ports may be opened for debugging but should remain closed in
 # production workloads.
-    ports:
-      - 9300:9300
-      - 9200:9200
+    # ports:
+    #   - 9300:9300
+    #   - 9200:9200
     volumes:
       - elastic_search_data:/usr/share/elasticsearch/data
-      # - ./data:/data # Exercise 1 - First - Ready to pull data from here
 
     deploy:
       resources:
         limits:
           cpus: '1.50'
           memory: 4G
-          
+
 volumes:
   elastic_search_data: {}
 

--- a/docker/mvt-elastic/docker-compose.yml
+++ b/docker/mvt-elastic/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
     depends_on:
       - elastic_search
-      
+
     restart: on-failure
 
   elastic_search:
@@ -69,7 +69,12 @@ services:
       - elastic_search_data:/usr/share/elasticsearch/data
       # - ./data:/data # Exercise 1 - First - Ready to pull data from here
 
-
+    deploy:
+      resources:
+        limits:
+          cpus: '1.50'
+          memory: 4G
+          
 volumes:
   elastic_search_data: {}
 


### PR DESCRIPTION
- Added restart policy to pygeoapi container, so it keeps trying until elastic is up
- Limit elastic container resources, in order to avoid it draining the host.